### PR TITLE
previouslyFocusedRect is nullable in the superclass

### DIFF
--- a/progressbutton/src/main/java/com/github/razir/progressbutton/AllCapsSpannedTransformationMethod.kt
+++ b/progressbutton/src/main/java/com/github/razir/progressbutton/AllCapsSpannedTransformationMethod.kt
@@ -30,7 +30,7 @@ class AllCapsSpannedTransformationMethod(context: Context) : TransformationMetho
 
     override fun onFocusChanged(
         view: View, sourceText: CharSequence, focused: Boolean, direction: Int,
-        previouslyFocusedRect: Rect
+        previouslyFocusedRect: Rect?
     ) {
     }
 


### PR DESCRIPTION
Kotlin crashes the app with an exception when attempting to set a drawable with a label on the button if `previouslyFocusedRect` is set to be non-null.