### PR TITLE
fix partial ring in the progress drawable for the first cycle

### DIFF
--- a/progressbutton/src/main/java/com/github/razir/progressbutton/DrawableButtonExtensions.kt
+++ b/progressbutton/src/main/java/com/github/razir/progressbutton/DrawableButtonExtensions.kt
@@ -180,9 +180,6 @@ private fun TextView.showDrawable(
 
     addDrawableAttachViewListener()
     setupDrawableCallback(this, drawable)
-    if (drawable is Animatable) {
-        drawable.start()
-    }
 }
 
 private fun setupDrawableCallback(textView: TextView, drawable: Drawable) {


### PR DESCRIPTION
The progress drawable's ring is only partially displayed for the first rotation as show in the gif below.
![progress-issue](https://user-images.githubusercontent.com/33973551/89714981-18bace80-d9c2-11ea-8580-46e6794f5431.gif)
I have fixed the issue, it was caused due to multiple calls to the start() function of the drawable (I was so stupid, it took me 3 hours to figure that out). You can see in the gif below, now the progress drawable behaves normally.
![progress-issue-fix](https://user-images.githubusercontent.com/33973551/89715014-561f5c00-d9c2-11ea-8d15-19aae141aed5.gif)

Forgive me if the multiple calls to the start() function is intentional.

